### PR TITLE
Ignore the gir file for the GirTest library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 #Rider
 *.idea
+
+# Ignore files that are copied here by gir.core/src/GenerateGirTestLib.fsx
+GirTest-0.1.gir


### PR DESCRIPTION
With https://github.com/gircore/gir.core/pull/764, the `GenerateGirTestLib.fsx` script installs the generated gir file into the gir-files folder, so this change avoids having untracked changes always appear in the gir-files submodule after building the native library