### PR TITLE
Add GtkSource-5.gir

### DIFF
--- a/.github/workflows/macos-update-gir-files.yml
+++ b/.github/workflows/macos-update-gir-files.yml
@@ -33,6 +33,7 @@ jobs:
           brew install gst-plugins-base
           brew install gst-plugins-good
           brew install gobject-introspection
+          brew install gtksourceview5
       - name: Extract gir files
         run: python transfer.py /usr/local/share/gir-1.0/ ./macos gir_files.txt
       - name: Create pull request

--- a/.github/workflows/windows-update-gir-files.yml
+++ b/.github/workflows/windows-update-gir-files.yml
@@ -29,6 +29,7 @@ jobs:
             mingw-w64-x86_64-gstreamer
             mingw-w64-x86_64-gst-plugins-good
             mingw-w64-x86_64-gst-plugins-base
+            mingw-w64-x86_64-gtksourceview5
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/gir_files.txt
+++ b/gir_files.txt
@@ -15,6 +15,7 @@ GstBase-1.0.gir
 GstPbutils-1.0.gir
 GstVideo-1.0.gir
 Gtk-4.0.gir
+GtkSource-5.gir
 HarfBuzz-0.0.gir
 Pango-1.0.gir
 PangoCairo-1.0.gir


### PR DESCRIPTION
Adding gtksourceview5 gir files. I've tested on linux and the gnome flatpak does indeed contain GtkSource-5.gir. With the added GtkSource-5.gir I'm able to generate the bindings but not build them yet.