### PR TITLE
Allow GstApp to update to 1.26

### DIFF
--- a/gir_files.txt
+++ b/gir_files.txt
@@ -10,7 +10,7 @@ GObject-2.0.gir,gobject-2.0,2.85.0
 Graphene-1.0.gir,graphene-gobject-1.0,1.11.0
 Gsk-4.0.gir,gtk4,4.19.0
 Gst-1.0.gir,gstreamer-1.0,1.25.0
-GstApp-1.0.gir,gstreamer-app-1.0,1.25.0
+GstApp-1.0.gir,gstreamer-app-1.0,1.27.0
 GstAudio-1.0.gir,gstreamer-audio-1.0,1.25.0
 GstBase-1.0.gir,gstreamer-base-1.0,1.25.0
 GstPbutils-1.0.gir,gstreamer-pbutils-1.0,1.25.0


### PR DESCRIPTION
GstApp got added at a point in time where Mac / Wndows packages only provide version 1.26 instead of the preferred 1.24 from Linux.

As there was no change between those versions it is fine to support 1.26 for all platforms.